### PR TITLE
Consolidate jobs in GitHub Pages deployment workflow

### DIFF
--- a/.github/workflows/deploy-to-github-pages.yml
+++ b/.github/workflows/deploy-to-github-pages.yml
@@ -19,42 +19,6 @@ concurrency:
   group: "pages"
   cancel-in-progress: false
 
-#
-#jobs:
-#  # Build job
-#  build:
-#    runs-on: ubuntu-latest
-#    steps:
-#      - name: Checkout
-#        uses: actions/checkout@v4
-#      - name: Setup .NET
-#        uses: actions/setup-dotnet@v4
-#        with:
-#          dotnet-version: 10.0.x
-#      - name: Prepare Blazor WASM for GitHub Pages
-#        uses: na1307/blazor-github-pages@v3
-#        id: prepare
-#        with:
-#          project-path: PackageReferenceCleaner/PackageReferenceCleaner.csproj
-#      - name: Setup Pages
-#        uses: actions/configure-pages@v5
-#      - name: Upload artifact
-#        uses: actions/upload-pages-artifact@v3
-#        with:
-#          path: ${{ steps.prepare.outputs.wwwroot-path }}
-#
-#  # Deployment job
-#  deploy:
-#    environment:
-#      name: github-pages
-#      url: ${{ steps.deployment.outputs.page_url }}
-#    runs-on: ubuntu-latest
-#    needs: build
-#    steps:
-#      - name: Deploy to GitHub Pages
-#        id: deployment
-#        uses: actions/deploy-pages@v4
-
 jobs:
   build-and-deploy:
     runs-on: ubuntu-latest
@@ -75,16 +39,16 @@ jobs:
       run: dotnet build --configuration Release --no-restore
 
     - name: Publish
-      run: dotnet publish PackageReferenceCleaner/PackageReferenceCleaner.csproj -c Release -p:BasePath="PackageReferenceCleaner" --nologo --no-build
+      run: dotnet publish PackageReferenceCleaner/PackageReferenceCleaner.csproj -c Release -p:BasePath="PackageReferenceCleaner" --nologo --no-build -o release
 
     - name: Change base-tag in index.html from / to BlazorGitHubPagesDemo
       run: sed -i 's/<base href="\/" \/>/<base href="\/PackageReferenceCleaner\/" \/>/g' release/wwwroot/index.html
     
     - name: Copy index.html to 404.html (for client-side routing)
-      run: cp wwwroot/index.html wwwroot/404.html
+      run: cp release/wwwroot/index.html release/wwwroot/404.html
 
     - name: Deploy to GitHub Pages
       uses: peaceiris/actions-gh-pages@v4
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
-        publish_dir: wwwroot
+        publish_dir: release/wwwroot


### PR DESCRIPTION
Updated `deploy-to-github-pages.yml` to merge build and deployment jobs into a single `build-and-deploy` job. Adjusted output directory references to `release/wwwroot` and modified file copy commands accordingly. Updated deployment step to use the new published directory path. #3